### PR TITLE
Touch Event Streamlining

### DIFF
--- a/RealityUI+Examples/RealityUI+Examples/ViewController+RealityControls.swift
+++ b/RealityUI+Examples/RealityUI+Examples/ViewController+RealityControls.swift
@@ -23,7 +23,6 @@ class ControlsParent: Entity, HasAnchoring, HasCollision, HasModel, HasPivotTouc
       .horizontal, classification: .any, minimumBounds: [0.5, 0.5]
     ))
     self.addControls()
-    /*
     /// Uncomment this to try out HasPivotTouch, but it's still in an experimental stage.
     if let rotateImg = try? TextureResource.load(named: "rotato") {
       self.collision = CollisionComponent(shapes: [.generateBox(size: [10, 0.1, 10])])
@@ -32,7 +31,6 @@ class ControlsParent: Entity, HasAnchoring, HasCollision, HasModel, HasPivotTouc
       unlitTextured.tintColor = unlitTextured.tintColor.withAlphaComponent(0.75)
       self.model = ModelComponent(mesh: .generatePlane(width: 1.5, depth: 1.5), materials: [unlitTextured])
     }
-     */
   }
 
   func entityAnchored() {

--- a/RealityUI+Examples/RealityUI+Examples/ViewController.swift
+++ b/RealityUI+Examples/RealityUI+Examples/ViewController.swift
@@ -25,7 +25,6 @@ class ViewController: UIViewController {
     let config = ARWorldTrackingConfiguration()
     config.planeDetection = [.horizontal]
     arView.session.run(config, options: [])
-
     // Replaces camera feed, if 6dof VR look is wanted
 //    arView.environment.background = .color(.systemGray)
 

--- a/Sources/RealityUI/HasPivotTouch.swift
+++ b/Sources/RealityUI/HasPivotTouch.swift
@@ -12,7 +12,7 @@ import RealityKit
 /// Hence no documentation yet.
 public protocol HasPivotTouch: HasPanTouch {}
 
-internal extension HasPivotTouch {
+public extension HasPivotTouch {
   var collisionPlane: float4x4? {
     return self.transformMatrix(relativeTo: nil)
       * float4x4(pivotRotation)

--- a/Sources/RealityUI/HasPivotTouch.swift
+++ b/Sources/RealityUI/HasPivotTouch.swift
@@ -12,6 +12,34 @@ import RealityKit
 /// Hence no documentation yet.
 public protocol HasPivotTouch: HasPanTouch {}
 
+internal extension HasPivotTouch {
+  var collisionPlane: float4x4? {
+    return self.transformMatrix(relativeTo: nil)
+      * float4x4(pivotRotation)
+  }
+
+  func arTouchStarted(_ worldCoordinate: SIMD3<Float>, hasCollided: Bool) {
+    self.lastGlobalPosition = worldCoordinate
+  }
+  func arTouchUpdated(_ worldCoordinate: SIMD3<Float>, hasCollided: Bool) {
+    var localPos = self.convert(position: worldCoordinate, from: nil)
+    localPos = self.pivotRotation.act(localPos)
+    var lastLocalPos = self.convert(position: self.lastGlobalPosition, from: nil)
+    lastLocalPos = self.pivotRotation.act(lastLocalPos)
+    let lastAngle = atan2f(lastLocalPos.x, lastLocalPos.z)
+    let angle = atan2f(localPos.x, localPos.z)
+
+    self.orientation *= simd_quatf(angle: angle - lastAngle, axis: self.pivotAxis)
+    self.lastGlobalPosition = worldCoordinate
+  }
+  func arTouchCancelled() {
+    self.arTouchEnded(nil)
+  }
+  func arTouchEnded(_ worldCoordinate: SIMD3<Float>?) {
+    self.lastGlobalPosition = .zero
+  }
+}
+
 public struct PivotComponent: Component {
   internal var lastTouchAngle: Float?
   internal var lastGlobalPosition: SIMD3<Float> = .zero

--- a/Sources/RealityUI/HasPivotTouch.swift
+++ b/Sources/RealityUI/HasPivotTouch.swift
@@ -21,31 +21,7 @@ public struct PivotComponent: Component {
   }
 }
 
-public extension HasPivotTouch {
-  func arTouchStarted(_ worldCoordinate: SIMD3<Float>) {
-    self.lastGlobalPosition = worldCoordinate
-  }
-  func arTouchUpdated(_ worldCoordinate: SIMD3<Float>) {
-    var localPos = self.convert(position: worldCoordinate, from: nil)
-    localPos = self.pivotRotation.act(localPos)
-    var lastLocalPos = self.convert(position: self.lastGlobalPosition, from: nil)
-    lastLocalPos = self.pivotRotation.act(lastLocalPos)
-    let lastAngle = atan2f(lastLocalPos.x, lastLocalPos.z)
-    let angle = atan2f(localPos.x, localPos.z)
-
-    self.orientation *= simd_quatf(angle: angle - lastAngle, axis: self.pivotAxis)
-    self.lastGlobalPosition = worldCoordinate
-  }
-  func arTouchEnded(_ worldCoordinate: SIMD3<Float>?) {
-    self.lastGlobalPosition = .zero
-  }
-}
-
-extension HasPivotTouch {
-  var collisionPlane: float4x4 {
-    return self.transformMatrix(relativeTo: nil)
-      * float4x4(pivotRotation)
-  }
+internal extension HasPivotTouch {
   var pivotRotation: simd_quatf {
     simd_quaternion(self.pivotAxis, [0, 1, 0])
   }

--- a/Sources/RealityUI/HasRUI.swift
+++ b/Sources/RealityUI/HasRUI.swift
@@ -78,7 +78,11 @@ public extension HasRUI {
 internal extension HasRUI {
   func getMaterial(with color: Material.Color) -> Material {
     var alpha: CGFloat = 0
+    #if os(macOS)
+    alpha = color.alphaComponent
+    #else
     color.getWhite(nil, alpha: &alpha)
+    #endif
     let adjustedColor = color.withAlphaComponent(alpha * (self.ruiEnabled ? 1 : 0.5))
     if self.RUI.respondsToLighting {
       return SimpleMaterial(color: adjustedColor, isMetallic: false)

--- a/Sources/RealityUI/RUIButton.swift
+++ b/Sources/RealityUI/RUIButton.swift
@@ -11,6 +11,8 @@ import RealityKit
 /// A  RealityUI Button to be added to a RealityKit scene.
 public class RUIButton: Entity, HasButton, HasModel, HasPhysics {
 
+  public var collisionPlane: float4x4? = nil
+
   public var touchUpCompleted: ((HasButton) -> Void)?
 
   /// Creates a RealityUI Button entity with optional `ButtonComponent`, `RUIComponent` and `updateCallback`.
@@ -32,6 +34,30 @@ public class RUIButton: Entity, HasButton, HasModel, HasPhysics {
   required public convenience init() {
     self.init(button: nil)
   }
+
+  public func arTouchStarted(_ worldCoordinate: SIMD3<Float>, hasCollided: Bool) {
+    self.compressButton()
+  }
+
+  public func arTouchUpdated(_ worldCoordinate: SIMD3<Float>, hasCollided: Bool) {
+    if hasCollided != self.isCompressed {
+      hasCollided ? self.compressButton() : self.releaseButton()
+    }
+  }
+
+  public func arTouchCancelled() {
+    if self.isCompressed {
+      self.releaseButton()
+    }
+  }
+
+  public func arTouchEnded(_ worldCoordinate: SIMD3<Float>?) {
+    if self.isCompressed {
+      self.releaseButton()
+      self.touchUpCompleted?(self)
+    }
+  }
+
 }
 
 public struct ButtonComponent: Component {
@@ -154,25 +180,6 @@ public extension HasButton {
   }
   private func addModel(part: ButtonComponent.UIPart) -> ModelEntity {
     return (self as HasRUI).addModel(part: part.rawValue)
-  }
-}
-
-public extension HasButton {
-  func arTouchStarted(hasCollided: Bool, _ worldCoordinate: SIMD3<Float>) {
-    self.compressButton()
-  }
-
-  func arTouchUpdated(hasCollided: Bool, _ worldCoordinate: SIMD3<Float>?) {
-    if hasCollided != self.isCompressed {
-      hasCollided ? self.compressButton() : self.releaseButton()
-    }
-  }
-
-  func arTouchEnded(_ worldCoordinate: SIMD3<Float>?) {
-    if self.isCompressed {
-      self.releaseButton()
-      self.touchUpCompleted?(self)
-    }
   }
 }
 


### PR DESCRIPTION
Updates:
- Moved touch functionality to classes rather than protocols (aside from PivotTouch)
- Setting touch state
- Handling touchesCancelled better

Fixes:
- Issue with getting alpha component on macOS