### PR TITLE
Texture Resource Helpers

### DIFF
--- a/Sources/RealityUI/RUIButton.swift
+++ b/Sources/RealityUI/RUIButton.swift
@@ -7,6 +7,9 @@
 //
 
 import RealityKit
+#if canImport(AppKit)
+import AppKit
+#endif
 
 /// A  RealityUI Button to be added to a RealityKit scene.
 public class RUIButton: Entity, HasButton, HasModel, HasPhysics {

--- a/Sources/RealityUI/RUILongTouchGestureRecognizer.swift
+++ b/Sources/RealityUI/RUILongTouchGestureRecognizer.swift
@@ -296,8 +296,9 @@ extension RUILongTouchGestureRecognizer {
         guard self.touchLocation != nil else {
             return
         }
+        let (newPos, hasCollided) = getCollisionPoints(touchLocation!)
         self.touchLocation = nil
-        entity?.arTouchEnded(at: nil, hasCollided: nil)
+        entity?.arTouchEnded(at: newPos, hasCollided: hasCollided)
         self.entity = nil
         self.viewSubscriber?.cancel()
     }

--- a/Sources/RealityUI/RUILongTouchGestureRecognizer.swift
+++ b/Sources/RealityUI/RUILongTouchGestureRecognizer.swift
@@ -272,7 +272,7 @@ extension RUILongTouchGestureRecognizer {
         else {
             return
         }
-        let touchInView = self.arView.convert(event.locationInWindow, from: event.window?.contentView)
+        let touchInView = self.arView.convert(event.locationInWindow, from: nil)
         //    self.activeTouch = touches.first
         if !globalTouchBegan(touchInView: touchInView) {
             self.mouseUp(with: event)
@@ -285,7 +285,7 @@ extension RUILongTouchGestureRecognizer {
             return
         }
 
-        let touchInView = self.arView.convert(event.locationInWindow, from: event.window?.contentView)
+        let touchInView = self.arView.convert(event.locationInWindow, from: nil)
 
         if touchInView == self.touchLocation {
             return

--- a/Sources/RealityUI/RUISlider.swift
+++ b/Sources/RealityUI/RUISlider.swift
@@ -8,6 +8,9 @@
 
 import Foundation
 import RealityKit
+#if canImport(AppKit)
+import AppKit
+#endif
 
 /// A  RealityUI Slider to be added to a RealityKit scene.
 public class RUISlider: Entity, HasSlider, HasModel {

--- a/Sources/RealityUI/RUIStepper.swift
+++ b/Sources/RealityUI/RUIStepper.swift
@@ -8,6 +8,9 @@
 
 import RealityKit
 import Combine
+#if canImport(AppKit)
+import AppKit
+#endif
 
 /// A new RealityUI Stepper to be added to your RealityKit scene.
 public class RUIStepper: Entity, HasRUIMaterials, HasStepper {

--- a/Sources/RealityUI/RUISwitch.swift
+++ b/Sources/RealityUI/RUISwitch.swift
@@ -7,6 +7,9 @@
 //
 
 import RealityKit
+#if canImport(AppKit)
+import AppKit
+#endif
 
 /// A  RealityUI Switch to be added to a RealityKit scene.
 public class RUISwitch: Entity, HasSwitch, HasPanTouch {

--- a/Sources/RealityUI/RUIText.swift
+++ b/Sources/RealityUI/RUIText.swift
@@ -8,6 +8,9 @@
 import CoreGraphics
 import RealityKit
 import CoreText
+#if canImport(AppKit)
+import AppKit
+#endif
 
 /// A RealityUI Text object to be added to a RealityKit scene.
 open class RUIText: Entity, HasText, HasClick {

--- a/Sources/RealityUI/RUITexture.swift
+++ b/Sources/RealityUI/RUITexture.swift
@@ -15,6 +15,7 @@ public typealias UIImage = NSImage
 #endif
 
 @available(iOS 15.0, macOS 12, *)
+/// Class for creating `TextureResources`. For now the main use-case is creating SF Symbol images.
 public struct RUITexture {
     /// Erorr that can be thrown while generating a texture
     public enum TextureError: Error {

--- a/Sources/RealityUI/RUITexture.swift
+++ b/Sources/RealityUI/RUITexture.swift
@@ -1,0 +1,95 @@
+//
+//  File.swift
+//  
+//
+//  Created by Max Cobb on 11/03/2023.
+//
+
+import RealityKit
+import CoreGraphics
+#if canImport(UIKit)
+import UIKit
+#elseif canImport(AppKit)
+import AppKit
+public typealias UIImage = NSImage
+#endif
+
+@available(iOS 15.0, macOS 12, *)
+public struct RUITexture {
+    public enum TextureError: Error {
+        case cgImageFailed
+        case invalidSystemName
+    }
+    public static func generatePaddedTexture(
+        systemName: String, pointSize: CGFloat
+    ) async throws -> TextureResource {
+        #if canImport(AppKit)
+        let config = NSImage.SymbolConfiguration(pointSize: pointSize, weight: .regular)
+        #elseif canImport(UIKit)
+        let config = UIImage.SymbolConfiguration(pointSize: pointSize, weight: .regular, scale: .default)
+        #endif
+        return try await self.generatePaddedTexture(systemName: systemName, config: config)
+    }
+    fileprivate static func generateCGImage(
+        systemName: String, config: UIImage.SymbolConfiguration
+    ) throws -> CGImage {
+        #if canImport(UIKit)
+        guard let symbolImage = UIImage(
+            systemName: systemName, withConfiguration: config
+        ) else { throw TextureError.invalidSystemName }
+        guard let cgImage = symbolImage.cgImage else {
+            throw TextureError.cgImageFailed
+        }
+        #else
+        guard let symbolImage = UIImage(
+            systemSymbolName: systemName, accessibilityDescription: nil
+        )?.withSymbolConfiguration(config) else { throw TextureError.invalidSystemName }
+        guard let cgImage = symbolImage.cgImage(
+            forProposedRect: nil, context: nil, hints: nil
+        ) else { throw TextureError.cgImageFailed }
+        #endif
+        return cgImage
+    }
+    public static func generatePaddedTexture(
+        systemName: String, config: UIImage.SymbolConfiguration
+    ) async throws -> TextureResource {
+        let cgImage = try self.generateCGImage(systemName: systemName, config: config)
+        #if canImport(AppKit)
+        return try await TextureResource.generate(from: cgImage, options: .init(semantic: nil, mipmapsMode: TextureResource.MipmapsMode.allocateAndGenerateAll))
+        #else
+        return try await withCheckedThrowingContinuation { continuation in
+            let generateTexture: @Sendable () -> Void = {
+                do {
+                    let texture = try TextureResource.generate(from: cgImage, withName: nil, options: .init(semantic: nil, mipmapsMode: TextureResource.MipmapsMode.allocateAndGenerateAll))
+                    continuation.resume(returning: texture)
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+            DispatchQueue.main.async(execute: generateTexture)
+        }
+        #endif
+    }
+
+    #if canImport(UIKit)
+    public static func generatePaddedTexture(
+        systemName: String, config: UIImage.SymbolConfiguration,
+        completion: @escaping (Result<TextureResource, Error>) -> Void
+    ) {
+        do {
+            let cgImage = try self.generateCGImage(systemName: systemName, config: config)
+            let generateTexture: @Sendable () -> Void = {
+                do {
+                    let texture = try TextureResource.generate(from: cgImage, withName: nil, options: .init(semantic: nil, mipmapsMode: TextureResource.MipmapsMode.allocateAndGenerateAll))
+                    completion(.success(texture))
+                } catch {
+                    completion(.failure(error))
+                }
+            }
+            DispatchQueue.main.async(execute: generateTexture)
+        } catch {
+            completion(.failure(error))
+        }
+    }
+    #endif
+}

--- a/Sources/RealityUI/RUITexture.swift
+++ b/Sources/RealityUI/RUITexture.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  RUITexture.swift
 //  
 //
 //  Created by Max Cobb on 11/03/2023.
@@ -16,11 +16,19 @@ public typealias UIImage = NSImage
 
 @available(iOS 15.0, macOS 12, *)
 public struct RUITexture {
+    /// Erorr that can be thrown while generating a texture
     public enum TextureError: Error {
+        /// Could not convert UIImage/NSImage to CGImage
         case cgImageFailed
+        /// System image with this name does not exist
         case invalidSystemName
     }
-    public static func generatePaddedTexture(
+    /// Create a `TextureResource` with a system image name and point size.
+    /// - Parameters:
+    ///   - systemName: Name of the SF Symbol Image.
+    ///   - pointSize: Point size the symbol will be drawn with.
+    /// - Returns: A new `TextureResource`.
+    public static func generateTexture(
         systemName: String, pointSize: CGFloat
     ) async throws -> TextureResource {
         #if canImport(AppKit)
@@ -28,7 +36,7 @@ public struct RUITexture {
         #elseif canImport(UIKit)
         let config = UIImage.SymbolConfiguration(pointSize: pointSize, weight: .regular, scale: .default)
         #endif
-        return try await self.generatePaddedTexture(systemName: systemName, config: config)
+        return try await self.generateTexture(systemName: systemName, config: config)
     }
     fileprivate static func generateCGImage(
         systemName: String, config: UIImage.SymbolConfiguration
@@ -50,7 +58,12 @@ public struct RUITexture {
         #endif
         return cgImage
     }
-    public static func generatePaddedTexture(
+    /// Create a `TextureResource` with a system image name and point size.
+    /// - Parameters:
+    ///   - systemName: Name of the SF Symbol Image.
+    ///   - config: Image SymbolConfiguration for the SF Symbol Image.
+    /// - Returns: A new `TextureResource`.
+    public static func generateTexture(
         systemName: String, config: UIImage.SymbolConfiguration
     ) async throws -> TextureResource {
         let cgImage = try self.generateCGImage(systemName: systemName, config: config)
@@ -71,8 +84,13 @@ public struct RUITexture {
         #endif
     }
 
-    #if canImport(UIKit)
-    public static func generatePaddedTexture(
+#if canImport(UIKit)
+    /// Create a `TextureResource` with a system image name and point size.
+    /// - Parameters:
+    ///   - systemName: Name of the SF Symbol Image.
+    ///   - config: Image SymbolConfiguration for the SF Symbol Image.
+    ///   - completion: Completion result for creating the `TextureResource`.
+    public static func generateTexture(
         systemName: String, config: UIImage.SymbolConfiguration,
         completion: @escaping (Result<TextureResource, Error>) -> Void
     ) {

--- a/Sources/RealityUI/RUITexture.swift
+++ b/Sources/RealityUI/RUITexture.swift
@@ -69,12 +69,18 @@ public struct RUITexture {
     ) async throws -> TextureResource {
         let cgImage = try self.generateCGImage(systemName: systemName, config: config)
         #if canImport(AppKit)
-        return try await TextureResource.generate(from: cgImage, options: .init(semantic: nil, mipmapsMode: TextureResource.MipmapsMode.allocateAndGenerateAll))
+        return try await TextureResource.generate(
+            from: cgImage,
+            options: .init(semantic: nil, mipmapsMode: TextureResource.MipmapsMode.allocateAndGenerateAll)
+        )
         #else
         return try await withCheckedThrowingContinuation { continuation in
             let generateTexture: @Sendable () -> Void = {
                 do {
-                    let texture = try TextureResource.generate(from: cgImage, withName: nil, options: .init(semantic: nil, mipmapsMode: TextureResource.MipmapsMode.allocateAndGenerateAll))
+                    let texture = try TextureResource.generate(
+                        from: cgImage, withName: nil,
+                        options: .init(semantic: nil, mipmapsMode: TextureResource.MipmapsMode.allocateAndGenerateAll)
+                    )
                     continuation.resume(returning: texture)
                 } catch {
                     continuation.resume(throwing: error)
@@ -99,7 +105,10 @@ public struct RUITexture {
             let cgImage = try self.generateCGImage(systemName: systemName, config: config)
             let generateTexture: @Sendable () -> Void = {
                 do {
-                    let texture = try TextureResource.generate(from: cgImage, withName: nil, options: .init(semantic: nil, mipmapsMode: TextureResource.MipmapsMode.allocateAndGenerateAll))
+                    let texture = try TextureResource.generate(
+                        from: cgImage, withName: nil,
+                        options: .init(semantic: nil, mipmapsMode: TextureResource.MipmapsMode.allocateAndGenerateAll)
+                    )
                     completion(.success(texture))
                 } catch {
                     completion(.failure(error))


### PR DESCRIPTION
> v1.4.0

- Added struct for loading SF Symbols as TextureResources.

Fixes:
- #13, thanks for the help @jgranie.
- Clicking RUISwitch, on macOS wasn't working as expected. (unrelated to the above issue)