### PR TITLE
Invalid Rotations

### DIFF
--- a/Sources/RealityUI/RUIButton.swift
+++ b/Sources/RealityUI/RUIButton.swift
@@ -298,7 +298,7 @@ internal extension HasButton {
         self.isCompressed = true
         innerModel.stopAllAnimations()
         innerModel.move(
-            to: Transform(scale: .one, rotation: .init(), translation: self.buttonInPos),
+            to: Transform(scale: .one, rotation: .init(angle: 0, axis: [0, 1, 0]), translation: self.buttonInPos),
             relativeTo: self, duration: 0.15
         )
     }
@@ -309,7 +309,7 @@ internal extension HasButton {
         self.isCompressed = false
         innerModel.stopAllAnimations()
         innerModel.move(
-            to: Transform(scale: .one, rotation: .init(), translation: self.buttonOutPos),
+            to: Transform(scale: .one, rotation: .init(angle: 0, axis: [0, 1, 0]), translation: self.buttonOutPos),
             relativeTo: self, duration: 0.15
         )
     }

--- a/Sources/RealityUI/RUIStepper.swift
+++ b/Sources/RealityUI/RUIStepper.swift
@@ -46,7 +46,7 @@ public class RUIStepper: Entity, HasRUIMaterials, HasStepper {
     public func arTouchUpdated(at worldCoordinate: SIMD3<Float>, hasCollided: Bool) {
         let localPos = self.convert(position: worldCoordinate, from: nil)
         let touchingObj: StepperComponent.UIPart = localPos.x > 0 ? .left : .right
-        if self.isCompressed, (!hasCollided || touchingObj != buttonStarted) {
+        if self.isCompressed, !hasCollided || touchingObj != buttonStarted {
             self.compressButton(compress: false)
         } else if !self.isCompressed, hasCollided, touchingObj == buttonStarted {
             self.compressButton()

--- a/Sources/RealityUI/RUISwitch.swift
+++ b/Sources/RealityUI/RUISwitch.swift
@@ -229,7 +229,7 @@ public extension HasSwitch {
 
         self.getModel(part: .background)?.model?.materials = self.getMaterials(for: .background)
         let thumbTransform = Transform(
-            scale: .one, rotation: .init(), translation: togglePos
+            scale: .one, rotation: .init(angle: 0, axis: [0, 1, 0]), translation: togglePos
         )
         let thumbEntity = self.getModel(part: .thumb)
         thumbEntity?.stopAllAnimations()


### PR DESCRIPTION
Fix a bug where button and toggle parts would disappear due to animations with `rotation: .init()`.